### PR TITLE
feat: Add kube-bench assessment for ck8s-etcd

### DIFF
--- a/cfg/ck8s-cis-1.24/config.yaml
+++ b/cfg/ck8s-cis-1.24/config.yaml
@@ -22,9 +22,9 @@ master:
       - /etc/kubernetes/controller.conf
   etcd:
     confs:
-      - /var/snap/k8s/common/args/k8s-dqlite
+      - /var/snap/k8s/common/args/etcd
     bins:
-      - k8s-dqlite
+      - etcd
 
 etcd:
   components:
@@ -32,12 +32,11 @@ etcd:
 
   etcd:
     bins:
-      - "k8s-dqlite"
+      - "etcd"
     confs:
-      - /var/snap/microk8s/common/args/k8s-dqlite
-    defaultconf: /var/snap/microk8s/common/args/k8s-dqlite
-    defaultdatadir: /var/snap/k8s/common/var/lib/k8s-dqlite
-
+      - /var/snap/k8s/common/args/etcd
+    defaultconf: /var/snap/k8s/common/args/etcd
+    defaultdatadir: /var/snap/k8s/common/var/lib/etcd/data
 node:
   kubelet:
     cafile:

--- a/cfg/ck8s-cis-1.24/etcd.yaml
+++ b/cfg/ck8s-cis-1.24/etcd.yaml
@@ -129,6 +129,6 @@ groups:
           Follow the etcd documentation and create a dedicated certificate authority setup for the
           etcd service.
           Then, edit the etcd pod specification file $etcdconf on the
-          master node and set the below parameter.
+          control plane node and set the below parameter.
           --trusted-ca-file=</path/to/ca-file>
         scored: false

--- a/cfg/ck8s-cis-1.24/etcd.yaml
+++ b/cfg/ck8s-cis-1.24/etcd.yaml
@@ -57,7 +57,7 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the etcd pod specification file $etcdconf on the master
+          Edit the etcd pod specification file $etcdconf on the control plane
           node and either remove the --auto-tls parameter or set it to false.
             --auto-tls=false
         scored: true

--- a/cfg/ck8s-cis-1.24/etcd.yaml
+++ b/cfg/ck8s-cis-1.24/etcd.yaml
@@ -76,7 +76,7 @@ groups:
           Follow the etcd service documentation and configure peer TLS encryption as appropriate
           for your etcd cluster.
           Then, edit the etcd pod specification file $etcdconf on the
-          master node and set the below parameters.
+          control plane node and set the below parameters.
           --peer-client-file=</path/to/peer-cert-file>
           --peer-key-file=</path/to/peer-key-file>
         scored: true

--- a/cfg/ck8s-cis-1.24/etcd.yaml
+++ b/cfg/ck8s-cis-1.24/etcd.yaml
@@ -37,7 +37,7 @@ groups:
                 op: eq
                 value: true
         remediation: |
-          Edit the etcd pod specification file $etcdconf on the master
+          Edit the etcd pod specification file $etcdconf on the control plane
           node and set the below parameter.
           --client-cert-auth="true"
         scored: true

--- a/cfg/ck8s-cis-1.24/etcd.yaml
+++ b/cfg/ck8s-cis-1.24/etcd.yaml
@@ -21,7 +21,7 @@ groups:
         remediation: |
           Follow the etcd service documentation and configure TLS encryption.
           Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml
-          on the master node and set the below parameters.
+          on the control plane node and set the below parameters.
           --cert-file=</path/to/ca-file>
           --key-file=</path/to/key-file>
         scored: true

--- a/cfg/ck8s-cis-1.24/etcd.yaml
+++ b/cfg/ck8s-cis-1.24/etcd.yaml
@@ -2,92 +2,133 @@
 controls:
 version: "cis-1.24"
 id: 2
-text: "Datastore Node Configuration"
+text: "Etcd Node Configuration"
 type: "etcd"
 groups:
   - id: 2
-    text: "Datastore Node Configuration"
+    text: "Etcd Node Configuration"
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
+          bin_op: and
           test_items:
-            - flag: "--not-applicable"
-              set: false
+            - flag: "--cert-file"
+              env: "ETCD_CERT_FILE"
+            - flag: "--key-file"
+              env: "ETCD_KEY_FILE"
         remediation: |
-          Not applicable. Canonical K8s uses dqlite and the communication to this service is done through a
-          local socket (/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock) accessible to users with root permissions.
+          Follow the etcd service documentation and configure TLS encryption.
+          Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml
+          on the master node and set the below parameters.
+          --cert-file=</path/to/ca-file>
+          --key-file=</path/to/key-file>
         scored: true
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
           test_items:
-            - flag: "--not-applicable"
-              set: false
+            - flag: "--client-cert-auth"
+              env: "ETCD_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
         remediation: |
-          Not applicable. Canonical K8s uses dqlite and the communication to this service is done through a
-          local socket (/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock) accessible to users with root permissions.
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --client-cert-auth="true"
         scored: true
 
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
+          bin_op: or
           test_items:
-            - flag: "--not-applicable"
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
               set: false
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
         remediation: |
-          Not applicable. Canonical K8s uses dqlite and the communication to this service is done through a
-          local socket (/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock) accessible to users with root permissions.
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --auto-tls parameter or set it to false.
+            --auto-tls=false
         scored: true
 
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
-        audit: "if test -e /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt && test -e /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.key; then echo 'certs-found'; fi"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
+          bin_op: and
           test_items:
-            - flag: "certs-found"
+            - flag: "--peer-cert-file"
+              env: "ETCD_PEER_CERT_FILE"
+            - flag: "--peer-key-file"
+              env: "ETCD_PEER_KEY_FILE"
         remediation: |
-          The certificate pair for dqlite and tls peer communication is
-          /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt and
-          /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.key.
+          Follow the etcd service documentation and configure peer TLS encryption as appropriate
+          for your etcd cluster.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameters.
+          --peer-client-file=</path/to/peer-cert-file>
+          --peer-key-file=</path/to/peer-key-file>
         scored: true
 
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
-        audit: "/bin/cat $etcdconf | /bin/grep enable-tls || true; echo $?"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
-          bin_op: or
           test_items:
-            - flag: "--enable-tls"
+            - flag: "--peer-client-cert-auth"
+              env: "ETCD_PEER_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
-            - flag: "--enable-tls"
-              set: false
         remediation: |
-          Dqlite peer communication uses TLS unless the --enable-tls is set to false in
-          /var/snap/k8s/common/args/k8s-dqlite.
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --peer-client-cert-auth=true
         scored: true
 
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
+          bin_op: or
           test_items:
-            - flag: "--not-applicable"
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
               set: false
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
         remediation: |
-          Not applicable. Canonical K8s uses dqlite and tls peer communication uses the certificates
-          created upon the snap creation.
-        scored: false
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --peer-auto-tls parameter or set it to false.
+          --peer-auto-tls=false
+        scored: true
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for the datastore (Manual)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
           test_items:
-            - flag: "--not-applicable"
-              set: false
+            - flag: "--trusted-ca-file"
+              env: "ETCD_TRUSTED_CA_FILE"
         remediation: |
-          Not applicable. Canonical K8s uses dqlite and tls peer communication uses certificates
-          created upon cluster setup.
-        scored: true
+          [Manual test]
+          Follow the etcd documentation and create a dedicated certificate authority setup for the
+          etcd service.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameter.
+          --trusted-ca-file=</path/to/ca-file>
+        scored: false

--- a/cfg/ck8s-cis-1.24/etcd.yaml
+++ b/cfg/ck8s-cis-1.24/etcd.yaml
@@ -92,7 +92,7 @@ groups:
                 op: eq
                 value: true
         remediation: |
-          Edit the etcd pod specification file $etcdconf on the master
+          Edit the etcd pod specification file $etcdconf on the control plane
           node and set the below parameter.
           --peer-client-cert-auth=true
         scored: true

--- a/cfg/ck8s-cis-1.24/etcd.yaml
+++ b/cfg/ck8s-cis-1.24/etcd.yaml
@@ -112,7 +112,7 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the etcd pod specification file $etcdconf on the master
+          Edit the etcd pod specification file $etcdconf on the control plane
           node and either remove the --peer-auto-tls parameter or set it to false.
           --peer-auto-tls=false
         scored: true

--- a/cfg/ck8s-cis-1.24/master.yaml
+++ b/cfg/ck8s-cis-1.24/master.yaml
@@ -90,32 +90,35 @@ groups:
         scored: true
 
       - id: 1.1.7
-        text: "Ensure that the dqlite configuration file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
+        text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
         use_multiple_values: true
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
-                value: "600"
+                value: "644"
         remediation: |
-          Run the following command on the control plane node.
-
-          `chmod 600 $etcdconf`
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 644 $etcdconf
         scored: true
 
       - id: 1.1.8
-        text: "Ensure that the dqlite configuration file ownership is set to root:root (Automated)"
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
         audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        use_multiple_values: true
         tests:
           test_items:
             - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
         remediation: |
-          Run the following command on the control plane node.
-
-          `chown root:root $etcdconf`
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
         scored: true
 
       - id: 1.1.9
@@ -151,36 +154,33 @@ groups:
         scored: false
 
       - id: 1.1.11
-        text: "Ensure that the dqlite data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          DATA_DIR='/var/snap/k8s/common/var/lib/k8s-dqlite'
-          stat -c permissions=%a "$DATA_DIR"
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: "stat -c permissions=%a /var/snap/k8s/common/var/lib/etcd/data"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
                 value: "700"
+              set: true
         remediation: |
-          Dqlite data are kept by default under /var/snap/k8s/common/var/lib/k8s-dqlite.
-          To comply with the spirit of this CIS recommendation:
-
-          `chmod 700 /var/snap/k8s/common/var/lib/k8s-dqlite`
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/snap/k8s/common/var/lib/etcd/data
         scored: true
 
       - id: 1.1.12
-        text: "Ensure that the dqlite data directory ownership is set to root:root (Automated)"
-        audit: |
-          DATA_DIR='/var/snap/k8s/common/var/lib/k8s-dqlite'
-          stat -c %U:%G "$DATA_DIR"
+        text: "Ensure that the etcd data directory ownership is set to root:root (Automated)"
+        audit: "stat -c %U:%G /var/snap/k8s/common/var/lib/etcd/data"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Dqlite data are kept by default under /var/snap/k8s/common/var/lib/k8s-dqlite.
-          To comply with the spirit of this CIS recommendation:
-
-          `chown root:root /var/snap/k8s/common/var/lib/k8s-dqlite`
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above).
+          For example, chown root:root /var/snap/k8s/common/var/lib/etcd/data
         scored: true
 
       - id: 1.1.13
@@ -722,14 +722,21 @@ groups:
 
       - id: 1.2.25
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
+          bin_op: and
           test_items:
-            - flag: "--not-applicable"
-              set: false
+            - flag: "--etcd-certfile"
+              set: true
+            - flag: "--etcd-keyfile"
+              set: true
         remediation: |
-          Not applicable. Canonical K8s uses dqlite and the communication to this service is done through a
-          local socket (/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock) accessible to users with root permissions.
-        scored: false
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the etcd certificate and key file parameters.
+          --etcd-certfile=<path/to/client-certificate-file>
+          --etcd-keyfile=<path/to/client-key-file>
+        scored: true
 
       - id: 1.2.26
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
@@ -765,15 +772,18 @@ groups:
         scored: true
 
       - id: 1.2.28
-        text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
-            - flag: "--not-applicable"
-              set: false
+            - flag: "--client-ca-file"
+              set: true
         remediation: |
-          Not applicable. Canonical K8s uses dqlite and the communication to this service is done through a
-          local socket (/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock) accessible to users with root permissions.
-        scored: false
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the client certificate authority file.
+          --client-ca-file=<path/to/client-ca-file>
+        scored: true
 
       - id: 1.2.29
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"


### PR DESCRIPTION
Update the Canonical kube-bench fork to support the Canonical Kubernetes with etcd backend.

See [this gist](https://gist.github.com/bschimke95/f36af8ab50c4254bca43ac15d1c7e390) for the audit run. Note that there are a few unrelated FAILs because I did not go through the hardening steps outlined [here](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/security/hardening/#how-to-harden-your-canonical-kubernetes-cluster)